### PR TITLE
prefix environment variable with VITE_

### DIFF
--- a/src/navigation/screens/HomeScreen.jsx
+++ b/src/navigation/screens/HomeScreen.jsx
@@ -8,6 +8,8 @@ import PlaceDetailsModal from './components/PlaceDetailsModal.jsx';
 import Toast from './components/Toast.jsx';
 import { addPlaceToPendingTrip } from './utils/tripDrafts.js';
 
+const nyc_env_var = import.meta.env.VITE_NYC_API_KEY;
+
 function HomeScreen() {
     
 
@@ -93,7 +95,7 @@ function HomeScreen() {
         try {
             const response = await fetch("https://api.nyc.gov/calendar/discover", {
                 headers: {
-                    "Ocp-Apim-Subscription-Key": process.env.NYC_API_KEY,
+                    "Ocp-Apim-Subscription-Key": nyc_env_var,
                     "Cache-Control": "no-cache"
                 }
             });


### PR DESCRIPTION
https://dev.to/stm-akikaze1119/understanding-environment-variables-in-vite-why-vite-prefix-is-important-5c3k

I just found out that vite environment variables need to have the prefix VITE_

We have to change the vercel env variable to be VITE_NYC_API_KEY

Screenshot from link above
<img width="753" height="509" alt="image" src="https://github.com/user-attachments/assets/41d69caa-c9b6-4f62-b55e-1c548dcee68e" />
