### PR TITLE
extend stop duration range and improve buffer label formatting

### DIFF
--- a/src/navigation/screens/NewTripScreen.jsx
+++ b/src/navigation/screens/NewTripScreen.jsx
@@ -680,9 +680,9 @@ function StopEntryBlock({data, onChange, index, onDelete, stopCount}) {
                         <input
                             id={`stop-duration-${index}`}
                             type="range"
-                            min="0"
-                            max="120"
-                            step="1"
+                            min="5"
+                            max="240"
+                            step="5"
                             value={data.duration}
                             onChange={(e) => onChange('duration', Number(e.target.value))}
                             className='slider'
@@ -709,17 +709,20 @@ function StopEntryBlock({data, onChange, index, onDelete, stopCount}) {
 }
 
 function formatBufferLabel(minutes) {
-    if (minutes >= 120) {
-        return '2 hours'
-    }
-    if (minutes >= 60) {
-        const remainder = minutes - 60
-        if (remainder === 0) {
-            return '1 hour'
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+
+    const hourText = h === 1 ? 'hour' : 'hours';
+    const minuteText = m === 1 ? 'minute' : 'minutes';
+
+    if (h > 0) {
+        if (m > 0) {
+            return `${h} ${hourText} ${m} ${minuteText}`;
         }
-        return `1 hour ${remainder} ${remainder === 1 ? 'minute' : 'minutes'}`
+        return `${h} ${hourText}`;
     }
-    return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
+
+    return `${m} ${minuteText}`;
 }
 
 export default NewTripScreen;


### PR DESCRIPTION
step amount is now 5 for the slider.
minimum of 5 mins, max of 4 hours
<img width="837" height="575" alt="image" src="https://github.com/user-attachments/assets/58d91166-63bc-4fdf-b360-9106f6c1d5f3" />
<img width="925" height="594" alt="image" src="https://github.com/user-attachments/assets/b0f9c047-6eda-4df5-b9fa-04ea54b04354" />
<img width="874" height="550" alt="image" src="https://github.com/user-attachments/assets/599d5779-25ec-4368-928e-c183f4089410" />
<img width="885" height="590" alt="image" src="https://github.com/user-attachments/assets/8c6313ee-7a11-4564-9dbf-095e5c2042bb" />
<img width="878" height="612" alt="image" src="https://github.com/user-attachments/assets/a06671f9-34f4-46a6-ad0d-8ce5c350a87f" />
